### PR TITLE
#142 Add application.cssのprecompileの設定を追加

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,6 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+# application.cssについてのエラー(Sprockets::Rails::Helper::AssetNotPrecompiled in)が出たため、追記
+Rails.application.config.assets.precompile += %w( application.css )


### PR DESCRIPTION
application.cssについてのエラー(Sprockets::Rails::Helper::AssetNotPrecompiled in)が出たため、assets.rbに追記